### PR TITLE
Store intermediate results

### DIFF
--- a/src/core/storage.py
+++ b/src/core/storage.py
@@ -12,6 +12,7 @@ class JobArtifact(str, Enum):
     """Types of artifacts that can be stored for a job."""
 
     SPEC = "spec"
+    PARSED_SPEC = "parsed_spec"
     SUMMARY = "summary"
     EXPORT = "export"
 
@@ -63,6 +64,13 @@ class JobStorage:
         logger.info(f"Saved {self.job_id} export to {export_path}")
         return export_path
 
+    def save_parsed_spec(self, parsed_spec: dict) -> Path:
+        """Save the parsed OpenAPI spec."""
+        parsed_spec_path = self.job_dir / "parsed_spec.json"
+        parsed_spec_path.write_text(str(parsed_spec))
+        logger.info(f"Saved {self.job_id} parsed spec to {parsed_spec_path}")
+        return parsed_spec_path
+
     def get_spec_path(self) -> Path | None:
         """Get the path to the spec file if it exists."""
         for ext in ["yaml", "json"]:
@@ -80,6 +88,11 @@ class JobStorage:
         """Get the path to an export file if it exists."""
         path = self.job_dir / f"summary.{format_}"
         return _get_and_log_path(path, self.job_id, JobArtifact.EXPORT)
+
+    def get_parsed_spec_path(self) -> Path | None:
+        """Get the path to the parsed spec file if it exists."""
+        path = self.job_dir / "parsed_spec.json"
+        return _get_and_log_path(path, self.job_id, JobArtifact.PARSED_SPEC)
 
     def ensure_export_exists(self, format_: ExportFormat) -> Path:
         """Ensure an export file exists, creating a placeholder if needed."""

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -30,7 +30,7 @@ class SpecAnalysis(BaseModel):
     endpoints: list[EndpointAnalysis]
 
 
-def analyze_spec(spec: ParsedSpec) -> SpecAnalysis:
+def get_llm_spec_analysis(spec: ParsedSpec) -> SpecAnalysis:
     """
     Analyze an OpenAPI specification using LLM.
 

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -1,22 +1,22 @@
 """Background tasks for API processing."""
 
 import json
+from typing import Any
 
 from celery import Task
 from loguru import logger
 
 from celery_worker import celery_app
 from src.core.storage import JobStorage
-from src.services.llm import analyze_spec
-from src.services.parser import parse_openapi_spec
+from src.services.llm import get_llm_spec_analysis
+from src.services.parser import ParsedSpec, parse_openapi_spec
 
 
 @celery_app.task(bind=True)
 def summarize_doc_task(
     self: Task, content: str, job_id: str, storage: JobStorage | None = None
-) -> dict:
-    """
-    Parse an OpenAPI spec and generate a summary.
+) -> dict[str, Any]:
+    """Parse an OpenAPI spec and generate a summary.
 
     Args:
         content: Raw OpenAPI spec content
@@ -30,41 +30,76 @@ def summarize_doc_task(
         Exception: If parsing or summarization fails
     """
     try:
-        # Use provided storage or create new one
-        storage = storage or JobStorage(job_id)
-        parsed_spec = None
-
-        # Check if we have a cached parsed spec
-        parsed_spec_path = storage.get_parsed_spec_path()
-        if parsed_spec_path:
-            try:
-                logger.info("Found cached parsed spec, attempting to load")
-                parsed_spec_content = parsed_spec_path.read_text()
-                parsed_spec = json.loads(parsed_spec_content)
-            except (json.JSONDecodeError, ValueError) as e:
-                logger.warning(f"Failed to load cached parsed spec: {e}")
-
-        if not parsed_spec:
-            # Parse and validate the spec
-            logger.info("Parsing OpenAPI spec")
-            parsed_spec = parse_openapi_spec(content)
-            # Cache the parsed spec
-            storage.save_parsed_spec(parsed_spec.model_dump())
-
-        # Generate summaries
-        logger.info("Generating API summary")
-        summary = analyze_spec(parsed_spec)
+        if storage is None:
+            storage = JobStorage(job_id)
+        return _process_spec(content, storage)
     except Exception as e:
         logger.error(f"Error processing spec: {e}")
         self.retry(exc=e, countdown=5, max_retries=3)
         raise  # This will never be reached, but makes mypy happy
-    else:
-        return {
-            "spec_info": {
-                "title": parsed_spec.title,
-                "version": parsed_spec.version,
-                "description": parsed_spec.description,
-            },
-            "summary": summary,
-            "endpoints": parsed_spec.endpoints,
-        }
+
+
+def _process_spec(content: str, storage: JobStorage) -> dict[str, Any]:
+    """Process an OpenAPI spec and generate summary.
+
+    Args:
+        content: Raw OpenAPI spec content
+        storage: Storage instance for caching
+
+    Returns:
+        Tuple of (parsed spec, summary)
+    """
+    parsed_spec = _load_cached_spec(storage)
+    if not parsed_spec:
+        parsed_spec = _parse_and_cache_spec(content, storage)
+
+    logger.info("Generating API summary")
+    summary = get_llm_spec_analysis(parsed_spec)
+
+    return {
+        "spec_info": {
+            "title": parsed_spec.title,
+            "version": parsed_spec.version,
+            "description": parsed_spec.description,
+        },
+        "summary": summary,
+        "endpoints": parsed_spec.endpoints,
+    }
+
+
+def _load_cached_spec(storage: JobStorage) -> ParsedSpec | None:
+    """Attempt to load cached spec.
+
+    Args:
+        storage: Storage instance to load from
+
+    Returns:
+        Parsed spec if found and valid, None otherwise
+    """
+    parsed_spec_path = storage.get_parsed_spec_path()
+    if not parsed_spec_path:
+        return None
+
+    try:
+        logger.info("Found cached parsed spec, attempting to load")
+        parsed_spec_content = parsed_spec_path.read_text()
+        return ParsedSpec.model_validate_json(parsed_spec_content)
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.warning(f"Failed to load cached parsed spec: {e}")
+        return None
+
+
+def _parse_and_cache_spec(content: str, storage: JobStorage) -> ParsedSpec:
+    """Parse spec and cache the result.
+
+    Args:
+        content: Raw OpenAPI spec content
+        storage: Storage instance for caching
+
+    Returns:
+        Parsed spec
+    """
+    logger.info("Parsing OpenAPI spec")
+    parsed_spec = parse_openapi_spec(content)
+    storage.save_parsed_spec(parsed_spec.model_dump())
+    return parsed_spec

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -1,20 +1,27 @@
 """Background tasks for API processing."""
 
+import json
+
 from celery import Task
 from loguru import logger
 
 from celery_worker import celery_app
+from src.core.storage import JobStorage
 from src.services.llm import analyze_spec
 from src.services.parser import parse_openapi_spec
 
 
 @celery_app.task(bind=True)
-def summarize_doc_task(self: Task, content: str) -> dict:
+def summarize_doc_task(
+    self: Task, content: str, job_id: str, storage: JobStorage | None = None
+) -> dict:
     """
     Parse an OpenAPI spec and generate a summary.
 
     Args:
         content: Raw OpenAPI spec content
+        job_id: Unique identifier for the job
+        storage: Optional storage instance (used in testing)
 
     Returns:
         dict: Structured summary of the API
@@ -23,9 +30,26 @@ def summarize_doc_task(self: Task, content: str) -> dict:
         Exception: If parsing or summarization fails
     """
     try:
-        # Parse and validate the spec
-        logger.info("Parsing OpenAPI spec")
-        parsed_spec = parse_openapi_spec(content)
+        # Use provided storage or create new one
+        storage = storage or JobStorage(job_id)
+        parsed_spec = None
+
+        # Check if we have a cached parsed spec
+        parsed_spec_path = storage.get_parsed_spec_path()
+        if parsed_spec_path:
+            try:
+                logger.info("Found cached parsed spec, attempting to load")
+                parsed_spec_content = parsed_spec_path.read_text()
+                parsed_spec = json.loads(parsed_spec_content)
+            except (json.JSONDecodeError, ValueError) as e:
+                logger.warning(f"Failed to load cached parsed spec: {e}")
+
+        if not parsed_spec:
+            # Parse and validate the spec
+            logger.info("Parsing OpenAPI spec")
+            parsed_spec = parse_openapi_spec(content)
+            # Cache the parsed spec
+            storage.save_parsed_spec(parsed_spec.model_dump())
 
         # Generate summaries
         logger.info("Generating API summary")

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from loguru import logger
 
-from src.services.llm import SpecAnalysis, analyze_spec
+from src.services.llm import SpecAnalysis, get_llm_spec_analysis
 from src.services.parser import parse_openapi_spec
 
 SAMPLES_PATH = Path(__file__).parent / "samples"
@@ -21,7 +21,7 @@ def test_analyze_petstore_spec() -> None:
     spec = parse_openapi_spec((SAMPLES_PATH / "petstore.yaml").read_text())
 
     # Analyze the spec using LLM
-    analysis = analyze_spec(spec)
+    analysis = get_llm_spec_analysis(spec)
 
     # Verify the structure of the response
     assert isinstance(analysis, SpecAnalysis)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,50 @@
+"""Tests for storage functionality."""
+
+from pathlib import Path
+
+import pytest
+
+from src.core.storage import JobStorage
+
+
+@pytest.fixture
+def job_storage(tmp_path: Path) -> JobStorage:
+    """Create a temporary JobStorage instance."""
+    job_id = "test-job"
+    storage = JobStorage(job_id)
+    # Override the job data root for testing
+    storage.job_dir = tmp_path / job_id
+    storage.job_dir.mkdir(parents=True, exist_ok=True)
+    return storage
+
+
+class TestJobStorage:
+    """Tests for JobStorage class."""
+
+    def test_save_parsed_spec(self, job_storage: JobStorage) -> None:
+        """Test saving a parsed spec."""
+        parsed_spec = {"title": "Test API", "version": "1.0.0", "endpoints": []}
+
+        path = job_storage.save_parsed_spec(parsed_spec)
+        assert path.exists()
+        assert path.name == "parsed_spec.json"
+
+        # Verify content
+        saved_content = path.read_text()
+        assert str(parsed_spec) in saved_content
+
+    def test_get_parsed_spec_path_exists(self, job_storage: JobStorage) -> None:
+        """Test getting path to existing parsed spec."""
+        # Create a parsed spec file
+        parsed_spec = {"title": "Test API"}
+        job_storage.save_parsed_spec(parsed_spec)
+
+        path = job_storage.get_parsed_spec_path()
+        assert path is not None
+        assert path.exists()
+        assert path.name == "parsed_spec.json"
+
+    def test_get_parsed_spec_path_not_exists(self, job_storage: JobStorage) -> None:
+        """Test getting path to non-existent parsed spec."""
+        path = job_storage.get_parsed_spec_path()
+        assert path is None

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,142 @@
+"""Tests for background tasks."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+from uuid import UUID
+
+import pytest
+
+from src.core.storage import JobStorage
+from src.services.parser import ParsedSpec
+from src.tasks.tasks import summarize_doc_task
+
+
+@pytest.fixture
+def job_id() -> str:
+    """Create a test job ID."""
+    return str(UUID("12345678-1234-5678-1234-567812345678"))
+
+
+@pytest.fixture
+def storage(job_id: str) -> JobStorage:
+    """Create a storage instance for testing."""
+    return JobStorage(job_id)
+
+
+@pytest.fixture
+def mock_storage(storage: JobStorage) -> Mock:
+    """Create a mock storage."""
+    with patch("src.core.storage.JobStorage", autospec=True) as mock:
+        mock.return_value = Mock(spec=storage)
+        yield mock.return_value
+
+
+@pytest.fixture
+def sample_spec() -> str:
+    """Create a sample OpenAPI spec."""
+    return """
+    openapi: 3.0.0
+    info:
+      title: Test API
+      version: 1.0.0
+    paths: {}
+    """
+
+
+class TestSummarizeDocTask:
+    """Tests for summarize_doc_task."""
+
+    def test_no_cache(self, mock_storage: Mock, sample_spec: str, job_id: str) -> None:
+        """Test task behavior when no cached spec exists."""
+        mock_storage.get_parsed_spec_path.return_value = None
+
+        parsed_spec = ParsedSpec(
+            title="Test API",
+            version="1.0.0",
+            description=None,
+            endpoints=[],
+            components={},
+        )
+
+        with (
+            patch("src.tasks.tasks.parse_openapi_spec") as mock_parse,
+            patch("src.tasks.tasks.analyze_spec") as mock_analyze,
+        ):
+            mock_parse.return_value = parsed_spec
+            mock_analyze.return_value = {"summary": "Test summary"}
+
+            result = summarize_doc_task(Mock(), sample_spec, job_id, mock_storage)
+
+            # Verify parsing was called
+            mock_parse.assert_called_once_with(sample_spec)
+            # Verify spec was cached
+            mock_storage.save_parsed_spec.assert_called_once_with(
+                parsed_spec.model_dump()
+            )
+
+            assert result["spec_info"]["title"] == "Test API"
+            assert result["summary"] == {"summary": "Test summary"}
+
+    def test_with_cache(
+        self, mock_storage: Mock, sample_spec: str, job_id: str, tmp_path: Path
+    ) -> None:
+        """Test task behavior when cached spec exists."""
+        cached_spec = {
+            "title": "Cached API",
+            "version": "1.0.0",
+            "description": None,
+            "endpoints": [],
+            "components": {},
+        }
+
+        # Set up mock for cached spec
+        mock_storage.get_parsed_spec_path.return_value = tmp_path / "parsed_spec.json"
+        with (tmp_path / "parsed_spec.json").open("w") as f:
+            json.dump(cached_spec, f)
+
+        with (
+            patch("src.tasks.tasks.parse_openapi_spec") as mock_parse,
+            patch("src.tasks.tasks.analyze_spec") as mock_analyze,
+        ):
+            mock_analyze.return_value = {"summary": "Test summary"}
+
+            result = summarize_doc_task(Mock(), sample_spec, job_id, mock_storage)
+
+            # Verify parsing was not called
+            mock_parse.assert_not_called()
+            # Verify cached spec was used
+            assert result["spec_info"]["title"] == "Cached API"
+            assert result["summary"] == {"summary": "Test summary"}
+
+    def test_no_storage_provided(self, sample_spec: str, job_id: str) -> None:
+        """Test task behavior when no storage is provided."""
+        parsed_spec = ParsedSpec(
+            title="Test API",
+            version="1.0.0",
+            description=None,
+            endpoints=[],
+            components={},
+        )
+
+        with (
+            patch("src.tasks.tasks.JobStorage") as mock_storage_class,
+            patch("src.tasks.tasks.parse_openapi_spec") as mock_parse,
+            patch("src.tasks.tasks.analyze_spec") as mock_analyze,
+        ):
+            mock_storage = Mock()
+            mock_storage_class.return_value = mock_storage
+            mock_storage.get_parsed_spec_path.return_value = None
+            mock_parse.return_value = parsed_spec
+            mock_analyze.return_value = {"summary": "Test summary"}
+
+            summarize_doc_task(Mock(), sample_spec, job_id)
+
+            # Verify storage was created with job_id
+            mock_storage_class.assert_called_once_with(job_id)
+            # Verify parsing was called
+            mock_parse.assert_called_once_with(sample_spec)
+            # Verify spec was cached
+            mock_storage.save_parsed_spec.assert_called_once_with(
+                parsed_spec.model_dump()
+            )


### PR DESCRIPTION
Store parsed spec as JSON - not important right now but will come in handy in future versions with more diverse prompts. 