### PR TITLE
Use a simpler health check

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,9 @@ primary_region = "lax"
 [env]
   PORT = "8080"
   PYTHONUNBUFFERED = "1"
+  ENV = "production"
+  LOG_LEVEL = "INFO"
+  # REDIS_URL will be automatically set when you attach Redis
 
 # Specify minimal VM size
 [processes]
@@ -45,10 +48,13 @@ app = "poetry run uvicorn src.main:app --host 0.0.0.0 --port 8080"
     restart_limit = 0
 
   [[services.http_checks]]
-    interval = "30s"
+    interval = "15s"
     timeout = "5s"
-    grace_period = "10s"
+    grace_period = "30s"
     restart_limit = 0
     method = "get"
-    path = "/api/health"
+    path = "/healthz"
     protocol = "http"
+
+[deploy]
+  strategy = "immediate"

--- a/fly.worker.toml
+++ b/fly.worker.toml
@@ -6,6 +6,9 @@ primary_region = "lax"
 
 [env]
   PYTHONUNBUFFERED = "1"
+  ENV = "production"
+  LOG_LEVEL = "INFO"
+  # REDIS_URL will be automatically set when you attach Redis
 
 # Use shared CPU
 [vm]
@@ -29,6 +32,9 @@ primary_region = "lax"
 
   [[services.tcp_checks]]
     interval = "30s"
-    timeout = "5s"
-    grace_period = "10s"
-    restart_limit = 0
+    timeout = "10s"
+    grace_period = "120s"
+    restart_limit = 3
+
+[deploy]
+  strategy = "immediate"

--- a/src/main.py
+++ b/src/main.py
@@ -42,6 +42,13 @@ async def read_root() -> FileResponse:
     return FileResponse(str(web_dir / "index.html"))
 
 
+# Add a simple health check that doesn't depend on external services
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    """Basic health check endpoint."""
+    return {"status": "healthy"}
+
+
 # Include routers
 app.include_router(router)
 


### PR DESCRIPTION
Skip Celery/Redis checks on deploy to allow for more independent deploy.